### PR TITLE
Add green prs to train when they're marked with the merge label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 coverage
 lib
 .DS_Store
+.idea

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -174,6 +174,25 @@ export = (cacheState: CacheState, config: Config): { state: State; app: Applicat
     }
   };
 
+  const checkSinglePr = async (pull_number: number, context: Context) => {
+    const {
+      data: { number, labels, mergeable_state },
+    } = await context.github.pulls.get({
+      ...context.repo(),
+      pull_number,
+    });
+
+    const mergeLabel = labels.find((label) => label.name == "ready to merge");
+
+    // if it's labeled and we're sure it can be merged...
+    if (mergeLabel && mergeable_state == "clean") {
+      // Add it to the proposed list
+      state.proposedTrain.push(number);
+
+      log(context, `${number} added to the proposed train: clean and ready to merge`);
+    }
+  };
+
   const logAndEnqueue = (
     job: ((context: Context) => Promise<void>) | (() => Promise<void>),
     type: string,
@@ -222,6 +241,8 @@ export = (cacheState: CacheState, config: Config): { state: State; app: Applicat
             if (state.proposedTrain.length == 0) {
               log(context, `PR ${number} labeled; proposed trains empty, starting`);
               await checkMergeTrain(context);
+            } else {
+              await checkSinglePr(number, context);
             }
           },
           "labeled",

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,9 @@ const config = {
 };
 
 Probot.prototype.load = ((originalLoad) => {
+  // tell us who you are
+  console.log('I AM THE EVIL MERGE BOT OF DOOOOOOM!!! FEAR ME WHILE I MERGE YOUR PRS!!!');
+
   // cast away...
   return function (this: Probot, app: string | ApplicationFunction): Application {
     //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,9 +23,6 @@ const config = {
 };
 
 Probot.prototype.load = ((originalLoad) => {
-  // tell us who you are
-  console.log("I AM THE EVIL MERGE BOT OF DOOOOOOM!!! FEAR ME WHILEST I MERGE YOUR PRS!!!");
-
   // cast away...
   return function (this: Probot, app: string | ApplicationFunction): Application {
     //eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,7 +24,7 @@ const config = {
 
 Probot.prototype.load = ((originalLoad) => {
   // tell us who you are
-  console.log('I AM THE EVIL MERGE BOT OF DOOOOOOM!!! FEAR ME WHILE I MERGE YOUR PRS!!!');
+  console.log("I AM THE EVIL MERGE BOT OF DOOOOOOM!!! FEAR ME WHILEST I MERGE YOUR PRS!!!");
 
   // cast away...
   return function (this: Probot, app: string | ApplicationFunction): Application {


### PR DESCRIPTION
If a proposed train already exists and you mark your PR as 'ready to merge' and the build is green, it won't get added to the merge train. We should add these PRs so that they get merged more quickly.