### PR TITLE
[CFE-535] Add support for bot wide code freeze

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -37,6 +37,8 @@ function repo(config: Config): Repo {
 
   let mergingEnabled = config.mutate;
   let enabled = config.mutate;
+  let enforceCodeFreeze = config.enforceCodeFreeze;
+  let codeFreezeBranchName = config.codeFreezeBranchName;
 
   const log = (context: Context, str: string): void => {
     decisionLog.push(str);
@@ -270,6 +272,20 @@ function repo(config: Config): Repo {
     },
     set mergingEnabled(state) {
       mergingEnabled = state;
+    },
+
+    get enforceCodeFreeze(): boolean {
+      return enforceCodeFreeze;
+    },
+    set enforceCodeFreeze(state) {
+      enforceCodeFreeze = state;
+    },
+
+    get codeFreezeBranchName(): string | undefined {
+      return codeFreezeBranchName;
+    },
+    set codeFreezeBranchName(state) {
+      codeFreezeBranchName = state;
     },
 
     on(action: string, context: Context): void {

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -29,8 +29,6 @@ function repo(config: Config): Repo {
   // use the old REST API because we can use ETags to avoid hitting our
   // rate limits
 
-  const { enforceCodeFreeze = false, codeFreezeBranchName = "" } = config;
-
   const proposedTrain = [] as Array<number>;
   const decisionLog = [] as Array<string>;
   const queue = new PQueue({
@@ -148,10 +146,12 @@ function repo(config: Config): Repo {
         const anyPending = statuses.some((status) => status.state == "pending");
 
         // Branch names are in the format 'mergeLocation:branchName'
-        const matchesCodeFreezeBranch = targetBranch.split(":")[1] === codeFreezeBranchName;
-
-        if (enforceCodeFreeze && !matchesCodeFreezeBranch) {
-          log(context, `${number} is not pointing towards the code freeze branch. It will not be merged`);
+        const matchesCodeFreezeBranch = targetBranch.split(":")[1] === config.codeFreezeBranchName;
+        if (config.enforceCodeFreeze && !matchesCodeFreezeBranch) {
+          log(
+            context,
+            `${number} is not pointing towards the code freeze branch ${config.codeFreezeBranchName}. It will not be merged`
+          );
         } else {
           // if it's labeled,
           if (mergeLabel) {
@@ -212,8 +212,9 @@ function repo(config: Config): Repo {
         pull_number,
       });
 
-      const matchesCodeFreezeBranch = targetBranch.split(":")[1] === codeFreezeBranchName;
-      if (enforceCodeFreeze && matchesCodeFreezeBranch) {
+      // Branch names are in the format 'merge-target:branch-name'
+      const matchesCodeFreezeBranch = targetBranch.split(":")[1] === config.codeFreezeBranchName;
+      if (config.enforceCodeFreeze && matchesCodeFreezeBranch) {
         return log(context, `${number} is not pointing towards the code freeze branch. It will not be merged`);
       }
 

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -148,11 +148,11 @@ function repo(config: Config): Repo {
         const anyPending = statuses.some((status) => status.state == "pending");
 
         // Branch names are in the format 'mergeLocation:branchName'
-        const matchesCodeFreezeBranch = targetBranch.split(":")[1] === config.codeFreezeBranchName;
-        if (config.enforceCodeFreeze && !matchesCodeFreezeBranch) {
+        const matchesCodeFreezeBranch = targetBranch.split(":")[1] === codeFreezeBranchName;
+        if (enforceCodeFreeze && !matchesCodeFreezeBranch) {
           log(
             context,
-            `${number} is not pointing towards the code freeze branch ${config.codeFreezeBranchName}. It will not be merged`
+            `${number} is not pointing towards the code freeze branch ${codeFreezeBranchName}. It will not be merged`
           );
         } else {
           // if it's labeled,
@@ -215,8 +215,8 @@ function repo(config: Config): Repo {
       });
 
       // Branch names are in the format 'merge-target:branch-name'
-      const matchesCodeFreezeBranch = targetBranch.split(":")[1] === config.codeFreezeBranchName;
-      if (config.enforceCodeFreeze && matchesCodeFreezeBranch) {
+      const matchesCodeFreezeBranch = targetBranch.split(":")[1] === codeFreezeBranchName;
+      if (enforceCodeFreeze && matchesCodeFreezeBranch) {
         return log(context, `${number} is not pointing towards the code freeze branch. It will not be merged`);
       }
 

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -139,7 +139,7 @@ function repo(config: Config): Repo {
               number,
               labels,
               mergeable_state,
-              head: { label },
+              head: { label: targetBranch },
             },
           },
         } = elem;
@@ -147,7 +147,7 @@ function repo(config: Config): Repo {
         const mergeLabel = labels.find((label) => label.name == "ready to merge");
         const anyPending = statuses.some((status) => status.state == "pending");
 
-        if (enforceCodeFreeze && !label.includes(codeFreezeBranchName)) {
+        if (enforceCodeFreeze && !targetBranch.includes(codeFreezeBranchName)) {
           log(context, `${number} is not pointing towards the code freeze branch. It will not be merged`);
         } else {
           // if it's labeled,
@@ -202,14 +202,14 @@ function repo(config: Config): Repo {
           number,
           labels,
           mergeable_state,
-          head: { label },
+          head: { label: targetBranch },
         },
       } = await context.github.pulls.get({
         ...context.repo(),
         pull_number,
       });
 
-      if (enforceCodeFreeze && !label.includes(codeFreezeBranchName)) {
+      if (enforceCodeFreeze && !targetBranch.includes(codeFreezeBranchName)) {
         return log(context, `${number} is not pointing towards the code freeze branch. It will not be merged`);
       }
 

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -10,7 +10,7 @@ import { CacheState } from "./cache";
 type Config = {
   mutate: boolean;
   debug: boolean;
-  enforceCodeFreeze?: boolean;
+  enforceCodeFreeze: boolean;
   codeFreezeBranchName?: string;
   appName: string;
   appRoute?: string;
@@ -147,7 +147,10 @@ function repo(config: Config): Repo {
         const mergeLabel = labels.find((label) => label.name == "ready to merge");
         const anyPending = statuses.some((status) => status.state == "pending");
 
-        if (enforceCodeFreeze && !targetBranch.includes(codeFreezeBranchName)) {
+        // Branch names are in the format 'mergeLocation:branchName'
+        const matchesCodeFreezeBranch = targetBranch.split(":")[1] === codeFreezeBranchName;
+
+        if (enforceCodeFreeze && !matchesCodeFreezeBranch) {
           log(context, `${number} is not pointing towards the code freeze branch. It will not be merged`);
         } else {
           // if it's labeled,
@@ -209,7 +212,8 @@ function repo(config: Config): Repo {
         pull_number,
       });
 
-      if (enforceCodeFreeze && !targetBranch.includes(codeFreezeBranchName)) {
+      const matchesCodeFreezeBranch = targetBranch.split(":")[1] === codeFreezeBranchName;
+      if (enforceCodeFreeze && matchesCodeFreezeBranch) {
         return log(context, `${number} is not pointing towards the code freeze branch. It will not be merged`);
       }
 

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -10,6 +10,8 @@ export interface Repo {
 
   enabled: boolean;
   mergingEnabled: boolean;
+  enforceCodeFreeze?: boolean;
+  codeFreezeBranchName?: string;
 }
 
 export type Repos = { [repo: string]: Repo };

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -87,7 +87,7 @@ rate limit remaining: ${cacheState.remainingLimit} out of ${cacheState.rateLimit
     if (repoName === "all") {
       Object.keys(repos).forEach((repoName) => {
         repos[repoName].enforceCodeFreeze = !repos[repoName].enforceCodeFreeze;
-        if (codeFreezeBranchName) repos[repoName].codeFreezeBranchName = codeFreezeBranchName;
+        repos[repoName].codeFreezeBranchName = codeFreezeBranchName;
       });
       if (Object.keys(repos).length)
         req.log(

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -89,11 +89,12 @@ rate limit remaining: ${cacheState.remainingLimit} out of ${cacheState.rateLimit
         repos[repoName].enforceCodeFreeze = !repos[repoName].enforceCodeFreeze;
         repos[repoName].codeFreezeBranchName = codeFreezeBranchName;
       });
-      if (Object.keys(repos).length)
+      if (Object.keys(repos).length) {
+        const firstRepo = repos[Object.keys(repos)[0]];
         req.log(
-          `changed all repository enforceCodeFreeze values to ${!repos[repoName]
-            .enforceCodeFreeze} and changed the code freeze branch name to ${codeFreezeBranchName}`
+          `changed all repository enforceCodeFreeze values to ${firstRepo.enforceCodeFreeze} and changed the code freeze branch name to ${codeFreezeBranchName}`
         );
+      }
     }
 
     res.redirect(root);

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ const cachedOctokit = ProbotOctokit.plugin(cache.plugin as any);
 const config = {
   mutate: !!process.env.MUTATE,
   debug: !!process.env.DEBUG,
+  enforceCodeFreeze: !!process.env.ENFORCE_CODE_FREEZE,
   appName: process.env.BOTNAME || "steward-bot",
 };
 

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -371,7 +371,7 @@ describe("steward-bot: merge", () => {
       expect(appRepos["repo-name"].proposedTrain).toEqual([123, 166]);
     });
 
-    test("should add branch to train to anything if enforceCodeFreeze is on and codeFreezeBranchName is unset ", async () => {
+    test("should not add branch to train if enforceCodeFreeze is on and codeFreezeBranchName is unset", async () => {
       probot = new Probot({ id: 1, cert: mockCert });
 
       const app = Merge(cacheState, { mutate: true, debug: false, appName: "steward-bot", enforceCodeFreeze: true });
@@ -410,10 +410,10 @@ describe("steward-bot: merge", () => {
       );
 
       await appRepos["repo-name"].queue.onIdle();
-      expect(appRepos["repo-name"].proposedTrain).toEqual([166]);
+      expect(appRepos["repo-name"].proposedTrain).toEqual([]);
     });
 
-    test("should not add branch to train if branch merges to master and enforceCodeFreeze is on and codeFreezeBranchName is set to something that isn't master", async () => {
+    test("should not add branch to train if branch target name is 'master' and enforceCodeFreeze is on and codeFreezeBranchName is set to something that isn't 'master'", async () => {
       probot = new Probot({ id: 1, cert: mockCert });
 
       const app = Merge(cacheState, {
@@ -461,7 +461,7 @@ describe("steward-bot: merge", () => {
       expect(appRepos["repo-name"].proposedTrain).toEqual([]);
     });
 
-    test('should add branch to train if branch merges to "test-freeze" and enforceCodeFreeze is on and codeFreezeBranchName is set to "test-freeze"', async () => {
+    test('should add branch to train if branch target name is "test-freeze" and enforceCodeFreeze is on and codeFreezeBranchName is set to "test-freeze"', async () => {
       probot = new Probot({ id: 1, cert: mockCert });
 
       const app = Merge(cacheState, {
@@ -487,7 +487,10 @@ describe("steward-bot: merge", () => {
 
       nock("https://api.github.com")
         .get("/repos/repo-owner/repo-name/pulls/166")
-        .reply(200, fixturePR({ number: 166, mergeable_state: "unknown", labelled: true, targetBranch: "test-freeze" }));
+        .reply(
+          200,
+          fixturePR({ number: 166, mergeable_state: "unknown", labelled: true, targetBranch: "test-freeze" })
+        );
 
       nock("https://api.github.com")
         .get("/repos/repo-owner/repo-name/commits/pr-166-sha-head/status")

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -126,7 +126,7 @@ describe("steward-bot: merge", () => {
   beforeEach(async () => {
     probot = new Probot({ id: 1, cert: mockCert });
 
-    const app = Merge(cacheState, { mutate: true, debug: false, appName: "steward-bot" });
+    const app = Merge(cacheState, { mutate: true, debug: false, appName: "steward-bot", enforceCodeFreeze: false });
     appRepos = app.repos;
 
     probot.load(app.app);

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -43,18 +43,18 @@ function fixturePR({
   number,
   mergeable_state,
   labelled,
-  branchLabel = "master",
+  targetBranch = "master",
 }: {
   number: number;
   mergeable_state: string;
   labelled: boolean;
-  branchLabel?: string;
+  targetBranch?: string;
 }): any {
   const pr = {
     number,
     head: {
       sha: `pr-${number}-sha-head`,
-      label: `github:${branchLabel}`,
+      label: `github:${targetBranch}`,
     },
     labels: [
       {
@@ -487,7 +487,7 @@ describe("steward-bot: merge", () => {
 
       nock("https://api.github.com")
         .get("/repos/repo-owner/repo-name/pulls/166")
-        .reply(200, fixturePR({ number: 166, mergeable_state: "unknown", labelled: true, branchLabel: "test-freeze" }));
+        .reply(200, fixturePR({ number: 166, mergeable_state: "unknown", labelled: true, targetBranch: "test-freeze" }));
 
       nock("https://api.github.com")
         .get("/repos/repo-owner/repo-name/commits/pr-166-sha-head/status")


### PR DESCRIPTION
Add code freeze to repo config. Prevent adding PRs to train if code freeze is turned on and the merge head is not the specified freeze branch. Add tests. Add UI so that we can change the code freeze status.

![image](https://user-images.githubusercontent.com/7645379/102404544-b93a8400-3f9c-11eb-95d5-26ad581cf80d.png)
