### PR TITLE
[CFE-503] Merge target is base not head... api oops

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -139,7 +139,7 @@ function repo(config: Config): Repo {
               number,
               labels,
               mergeable_state,
-              head: { label: targetBranch },
+              base: { label: targetBranch },
             },
           },
         } = elem;
@@ -207,7 +207,7 @@ function repo(config: Config): Repo {
           number,
           labels,
           mergeable_state,
-          head: { label: targetBranch },
+          base: { label: targetBranch },
         },
       } = await context.github.pulls.get({
         ...context.repo(),

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -54,6 +54,8 @@ function fixturePR({
     number,
     head: {
       sha: `pr-${number}-sha-head`,
+    },
+    base:{
       label: `github:${targetBranch}`,
     },
     labels: [


### PR DESCRIPTION
Merge target is `base` not `head`. I couldn't glean this from the API docs but now i know....